### PR TITLE
Switch to .NET Framework 4.5

### DIFF
--- a/TASCompDisplay/App.config
+++ b/TASCompDisplay/App.config
@@ -6,7 +6,7 @@
         </sectionGroup>
     </configSections>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
     </startup>
     <userSettings>
         <TASCompDisplay.Properties.Settings>

--- a/TASCompDisplay/TASCompDisplay.csproj
+++ b/TASCompDisplay/TASCompDisplay.csproj
@@ -8,10 +8,11 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>TASCompDisplay</RootNamespace>
     <AssemblyName>TASCompDisplay</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -33,11 +34,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms.DataVisualization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -119,6 +123,7 @@
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
+      <DesignTime>True</DesignTime>
     </Compile>
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">

--- a/TASCompDisplay/frm_Main.Designer.cs
+++ b/TASCompDisplay/frm_Main.Designer.cs
@@ -430,32 +430,31 @@
 			this.lbl_addRerecords.TabIndex = 15;
 			this.lbl_addRerecords.Text = "Rerecords:";
 			// 
-			// label1
 			// 
-			this.label1.AutoSize = true;
 			this.label1.Font = new System.Drawing.Font("Super Mario Odyssey", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this.label1.Location = new System.Drawing.Point(-2, 24);
 			this.label1.Name = "label1";
 			this.label1.Size = new System.Drawing.Size(227, 37);
 			this.label1.TabIndex = 16;
 			this.label1.Text = "Add Competitor";
+			this.lbl_AddCompetitor.Location = new System.Drawing.Point(28, 29);
 			// 
 			// dataGrid_TASData
 			// 
 			this.dataGrid_TASData.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
 			this.dataGrid_TASData.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.Place,
-            this.Username,
-            this.StartingFrame,
-            this.EndingFrame,
-            this.Frames,
-            this.Rerecords,
-            this.DQ,
-            this.DQReason});
+			this.Place,
+			this.Username,
+			this.StartingFrame,
+			this.EndingFrame,
+			this.Frames,
+			this.Rerecords,
+			this.DQ,
+			this.DQReason});
 			this.dataGrid_TASData.Dock = System.Windows.Forms.DockStyle.Fill;
 			this.dataGrid_TASData.Location = new System.Drawing.Point(3, 3);
 			this.dataGrid_TASData.Name = "dataGrid_TASData";
-			this.dataGrid_TASData.Size = new System.Drawing.Size(678, 294);
+			this.dataGrid_TASData.Size = new System.Drawing.Size(693, 294);
 			this.dataGrid_TASData.TabIndex = 17;
 			// 
 			// Place
@@ -518,12 +517,15 @@
 			// 
 			// tab_DataGrids
 			// 
+			this.tab_DataGrids.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+			| System.Windows.Forms.AnchorStyles.Left) 
+			| System.Windows.Forms.AnchorStyles.Right)));
 			this.tab_DataGrids.Controls.Add(this.tab_CompLeaderboard);
 			this.tab_DataGrids.Controls.Add(this.tab_PointLeaderboard);
 			this.tab_DataGrids.Location = new System.Drawing.Point(231, 27);
 			this.tab_DataGrids.Name = "tab_DataGrids";
 			this.tab_DataGrids.SelectedIndex = 0;
-			this.tab_DataGrids.Size = new System.Drawing.Size(692, 326);
+			this.tab_DataGrids.Size = new System.Drawing.Size(707, 326);
 			this.tab_DataGrids.TabIndex = 19;
 			// 
 			// tab_CompLeaderboard
@@ -532,7 +534,7 @@
 			this.tab_CompLeaderboard.Location = new System.Drawing.Point(4, 22);
 			this.tab_CompLeaderboard.Name = "tab_CompLeaderboard";
 			this.tab_CompLeaderboard.Padding = new System.Windows.Forms.Padding(3);
-			this.tab_CompLeaderboard.Size = new System.Drawing.Size(684, 300);
+			this.tab_CompLeaderboard.Size = new System.Drawing.Size(699, 300);
 			this.tab_CompLeaderboard.TabIndex = 0;
 			this.tab_CompLeaderboard.Text = "Competition Leaderboard";
 			this.tab_CompLeaderboard.UseVisualStyleBackColor = true;
@@ -552,9 +554,9 @@
 			// 
 			this.dataGrid_TASPoints.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
 			this.dataGrid_TASPoints.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.PointPlace,
-            this.PointUsername,
-            this.PointScore});
+			this.PointPlace,
+			this.PointUsername,
+			this.PointScore});
 			this.dataGrid_TASPoints.Dock = System.Windows.Forms.DockStyle.Fill;
 			this.dataGrid_TASPoints.Location = new System.Drawing.Point(3, 3);
 			this.dataGrid_TASPoints.Name = "dataGrid_TASPoints";
@@ -577,45 +579,14 @@
 			this.PointScore.HeaderText = "Score";
 			this.PointScore.Name = "PointScore";
 			// 
-			// dataAnalysisToolStripMenuItem
-			// 
-			this.dataAnalysisToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.graphDisplayToolStripMenuItem});
-			this.dataAnalysisToolStripMenuItem.Name = "dataAnalysisToolStripMenuItem";
-			this.dataAnalysisToolStripMenuItem.Size = new System.Drawing.Size(123, 20);
-			this.dataAnalysisToolStripMenuItem.Text = "&Data Analysis (beta)";
-			// 
-			// graphDisplayToolStripMenuItem
-			// 
-			this.graphDisplayToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.leaderboardToolStripMenuItem,
-            this.pointLeaderboardToolStripMenuItem3});
-			this.graphDisplayToolStripMenuItem.Name = "graphDisplayToolStripMenuItem";
-			this.graphDisplayToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-			this.graphDisplayToolStripMenuItem.Text = "Graph Display";
-			// 
-			// leaderboardToolStripMenuItem
-			// 
-			this.leaderboardToolStripMenuItem.Name = "leaderboardToolStripMenuItem";
-			this.leaderboardToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
-			this.leaderboardToolStripMenuItem.Text = "Competition Leaderboard";
-			this.leaderboardToolStripMenuItem.Click += new System.EventHandler(this.leaderboardToolStripMenuItem_Click);
-			// 
-			// pointLeaderboardToolStripMenuItem3
-			// 
-			this.pointLeaderboardToolStripMenuItem3.Name = "pointLeaderboardToolStripMenuItem3";
-			this.pointLeaderboardToolStripMenuItem3.Size = new System.Drawing.Size(210, 22);
-			this.pointLeaderboardToolStripMenuItem3.Text = "Point Leaderboard";
-			this.pointLeaderboardToolStripMenuItem3.Click += new System.EventHandler(this.pointLeaderboardToolStripMenuItem3_Click);
-			// 
 			// frm_Main
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(935, 378);
+			this.ClientSize = new System.Drawing.Size(942, 378);
 			this.Controls.Add(this.tab_DataGrids);
 			this.Controls.Add(this.btn_AddCompetitor);
-			this.Controls.Add(this.label1);
+			this.Controls.Add(this.lbl_AddCompetitor);
 			this.Controls.Add(this.lbl_addRerecords);
 			this.Controls.Add(this.lbl_addEnding);
 			this.Controls.Add(this.lbl_addStarting);
@@ -628,10 +599,10 @@
 			this.Controls.Add(this.txt_addUsername);
 			this.Controls.Add(this.statusStrip1);
 			this.Controls.Add(this.menuStrip);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
 			this.MainMenuStrip = this.menuStrip;
 			this.MaximizeBox = false;
 			this.MinimizeBox = false;
+			this.MinimumSize = new System.Drawing.Size(958, 417);
 			this.Name = "frm_Main";
 			this.Text = "TAS Comp Display Tool";
 			this.menuStrip.ResumeLayout(false);
@@ -670,7 +641,7 @@
 		private System.Windows.Forms.Label lbl_addEnding;
 		private System.Windows.Forms.Label lbl_addRerecords;
 		private System.Windows.Forms.CheckBox chk_DQ_M64Early;
-		private System.Windows.Forms.Label label1;
+		private System.Windows.Forms.Label lbl_AddCompetitor;
 		private System.Windows.Forms.DataGridView dataGrid_TASData;
 		private System.Windows.Forms.Label lbl_DQ_Other;
 		private System.Windows.Forms.TextBox txt_DQ_Other;

--- a/TASCompDisplay/frm_Main.Designer.cs
+++ b/TASCompDisplay/frm_Main.Designer.cs
@@ -45,6 +45,10 @@
 			this.rerankBoardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.scorePointsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.liveDisplayToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.dataAnalysisToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.graphDisplayToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.leaderboardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.pointLeaderboardToolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
 			this.statusStrip1 = new System.Windows.Forms.StatusStrip();
 			this.toolStripStatusLabel_CurrentFile = new System.Windows.Forms.ToolStripStatusLabel();
 			this.toolStripStatusLabel_OpenedFile = new System.Windows.Forms.ToolStripStatusLabel();
@@ -66,7 +70,7 @@
 			this.lbl_addStarting = new System.Windows.Forms.Label();
 			this.lbl_addEnding = new System.Windows.Forms.Label();
 			this.lbl_addRerecords = new System.Windows.Forms.Label();
-			this.label1 = new System.Windows.Forms.Label();
+			this.lbl_AddCompetitor = new System.Windows.Forms.Label();
 			this.dataGrid_TASData = new System.Windows.Forms.DataGridView();
 			this.Place = new System.Windows.Forms.DataGridViewTextBoxColumn();
 			this.Username = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -84,10 +88,6 @@
 			this.PointPlace = new System.Windows.Forms.DataGridViewTextBoxColumn();
 			this.PointUsername = new System.Windows.Forms.DataGridViewTextBoxColumn();
 			this.PointScore = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.dataAnalysisToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.graphDisplayToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.leaderboardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.pointLeaderboardToolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
 			this.menuStrip.SuspendLayout();
 			this.statusStrip1.SuspendLayout();
 			this.groupBox_DQReasons.SuspendLayout();
@@ -101,26 +101,26 @@
 			// menuStrip
 			// 
 			this.menuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.fileToolStripMenuItem,
-            this.aboutToolStripMenuItem,
-            this.exportPlainTextToolStripMenuItem,
-            this.rerankBoardToolStripMenuItem,
-            this.scorePointsToolStripMenuItem,
-            this.liveDisplayToolStripMenuItem,
-            this.dataAnalysisToolStripMenuItem});
+			this.fileToolStripMenuItem,
+			this.aboutToolStripMenuItem,
+			this.exportPlainTextToolStripMenuItem,
+			this.rerankBoardToolStripMenuItem,
+			this.scorePointsToolStripMenuItem,
+			this.liveDisplayToolStripMenuItem,
+			this.dataAnalysisToolStripMenuItem});
 			this.menuStrip.Location = new System.Drawing.Point(0, 0);
 			this.menuStrip.Name = "menuStrip";
-			this.menuStrip.Size = new System.Drawing.Size(935, 24);
+			this.menuStrip.Size = new System.Drawing.Size(942, 24);
 			this.menuStrip.TabIndex = 1;
 			this.menuStrip.Text = "menuStrip1";
 			// 
 			// fileToolStripMenuItem
 			// 
 			this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.newToolStripMenuItem,
-            this.openToolStripMenuItem,
-            this.saveToolStripMenuItem,
-            this.exitToolStripMenuItem});
+			this.newToolStripMenuItem,
+			this.openToolStripMenuItem,
+			this.saveToolStripMenuItem,
+			this.exitToolStripMenuItem});
 			this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
 			this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
 			this.fileToolStripMenuItem.Text = "&File";
@@ -135,8 +135,8 @@
 			// openToolStripMenuItem
 			// 
 			this.openToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.competitionLeaderboardToolStripMenuItem1,
-            this.pointLeaderboardToolStripMenuItem1});
+			this.competitionLeaderboardToolStripMenuItem1,
+			this.pointLeaderboardToolStripMenuItem1});
 			this.openToolStripMenuItem.Name = "openToolStripMenuItem";
 			this.openToolStripMenuItem.Size = new System.Drawing.Size(103, 22);
 			this.openToolStripMenuItem.Text = "&Open";
@@ -158,8 +158,8 @@
 			// saveToolStripMenuItem
 			// 
 			this.saveToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.competitionLeaderboardToolStripMenuItem,
-            this.pointLeaderboardToolStripMenuItem});
+			this.competitionLeaderboardToolStripMenuItem,
+			this.pointLeaderboardToolStripMenuItem});
 			this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
 			this.saveToolStripMenuItem.Size = new System.Drawing.Size(103, 22);
 			this.saveToolStripMenuItem.Text = "&Save";
@@ -195,8 +195,8 @@
 			// exportPlainTextToolStripMenuItem
 			// 
 			this.exportPlainTextToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.competitionLeaderboardToolStripMenuItem2,
-            this.pointLeaderboardToolStripMenuItem2});
+			this.competitionLeaderboardToolStripMenuItem2,
+			this.pointLeaderboardToolStripMenuItem2});
 			this.exportPlainTextToolStripMenuItem.Name = "exportPlainTextToolStripMenuItem";
 			this.exportPlainTextToolStripMenuItem.Size = new System.Drawing.Size(105, 20);
 			this.exportPlainTextToolStripMenuItem.Text = "&Export Plain Text";
@@ -236,14 +236,45 @@
 			this.liveDisplayToolStripMenuItem.Text = "&Live Display";
 			this.liveDisplayToolStripMenuItem.Click += new System.EventHandler(this.liveDisplayToolStripMenuItem_Click);
 			// 
+			// dataAnalysisToolStripMenuItem
+			// 
+			this.dataAnalysisToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.graphDisplayToolStripMenuItem});
+			this.dataAnalysisToolStripMenuItem.Name = "dataAnalysisToolStripMenuItem";
+			this.dataAnalysisToolStripMenuItem.Size = new System.Drawing.Size(123, 20);
+			this.dataAnalysisToolStripMenuItem.Text = "&Data Analysis (beta)";
+			// 
+			// graphDisplayToolStripMenuItem
+			// 
+			this.graphDisplayToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.leaderboardToolStripMenuItem,
+			this.pointLeaderboardToolStripMenuItem3});
+			this.graphDisplayToolStripMenuItem.Name = "graphDisplayToolStripMenuItem";
+			this.graphDisplayToolStripMenuItem.Size = new System.Drawing.Size(147, 22);
+			this.graphDisplayToolStripMenuItem.Text = "Graph Display";
+			// 
+			// leaderboardToolStripMenuItem
+			// 
+			this.leaderboardToolStripMenuItem.Name = "leaderboardToolStripMenuItem";
+			this.leaderboardToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
+			this.leaderboardToolStripMenuItem.Text = "Competition Leaderboard";
+			this.leaderboardToolStripMenuItem.Click += new System.EventHandler(this.leaderboardToolStripMenuItem_Click);
+			// 
+			// pointLeaderboardToolStripMenuItem3
+			// 
+			this.pointLeaderboardToolStripMenuItem3.Name = "pointLeaderboardToolStripMenuItem3";
+			this.pointLeaderboardToolStripMenuItem3.Size = new System.Drawing.Size(210, 22);
+			this.pointLeaderboardToolStripMenuItem3.Text = "Point Leaderboard";
+			this.pointLeaderboardToolStripMenuItem3.Click += new System.EventHandler(this.pointLeaderboardToolStripMenuItem3_Click);
+			// 
 			// statusStrip1
 			// 
 			this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripStatusLabel_CurrentFile,
-            this.toolStripStatusLabel_OpenedFile});
+			this.toolStripStatusLabel_CurrentFile,
+			this.toolStripStatusLabel_OpenedFile});
 			this.statusStrip1.Location = new System.Drawing.Point(0, 356);
 			this.statusStrip1.Name = "statusStrip1";
-			this.statusStrip1.Size = new System.Drawing.Size(935, 22);
+			this.statusStrip1.Size = new System.Drawing.Size(942, 22);
 			this.statusStrip1.TabIndex = 2;
 			this.statusStrip1.Text = "statusStrip1";
 			// 
@@ -430,14 +461,15 @@
 			this.lbl_addRerecords.TabIndex = 15;
 			this.lbl_addRerecords.Text = "Rerecords:";
 			// 
+			// lbl_AddCompetitor
 			// 
-			this.label1.Font = new System.Drawing.Font("Super Mario Odyssey", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label1.Location = new System.Drawing.Point(-2, 24);
-			this.label1.Name = "label1";
-			this.label1.Size = new System.Drawing.Size(227, 37);
-			this.label1.TabIndex = 16;
-			this.label1.Text = "Add Competitor";
+			this.lbl_AddCompetitor.AutoSize = true;
+			this.lbl_AddCompetitor.Font = new System.Drawing.Font("Microsoft Sans Serif", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this.lbl_AddCompetitor.Location = new System.Drawing.Point(28, 29);
+			this.lbl_AddCompetitor.Name = "lbl_AddCompetitor";
+			this.lbl_AddCompetitor.Size = new System.Drawing.Size(174, 25);
+			this.lbl_AddCompetitor.TabIndex = 16;
+			this.lbl_AddCompetitor.Text = "Add Competitor";
 			// 
 			// dataGrid_TASData
 			// 

--- a/TASCompDisplay/packages.config
+++ b/TASCompDisplay/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net45" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The current target framework version is the latest and greatest 4.7.1. However, this version brings compatibility issues with some modern computers. While all modern major versions can run it, Windows 10 requires a major update to support versions 4.7 and later. This means that people who prefer staying on the old, release build of Windows 10 for various reasons (most importantly the ability to disable automatic updates), cannot run the application. I'm part of this minority myself.

Upon investigation, the app does not use any features present only in 4.7 - aside from System.ValueTuple. However, System.ValueTuple is available in older versions of .NET via a NuGet package, which allows normal operation on older versions without the need to change the source code. I've changed the target framework to version 4.5, added System.ValueTuple as a Package, and also updated Newtonsoft.Json to version 12. This should make it run properly on just about every modern system.

Was intending to open a separate pull for the resizing bit, but it got merged automatically to the pull request here as I commited.